### PR TITLE
infrastructure nodes and logging

### DIFF
--- a/roles/infrastructure-nodes/README.md
+++ b/roles/infrastructure-nodes/README.md
@@ -1,0 +1,19 @@
+This role requires that a variable `azs` with a list of AZs to create infra nodes be set.
+
+For example:
+
+```sh
+ansible-playbook -e api_url=`oc whoami --show-server` -e '{"azs":["us-east-1"]}' play.yaml
+```
+
+Use of this role requires the `openshift` python module. On RHEL7 you can install `python-openshift`
+
+To cleanup (probably don't really want to do this in a live cluster)
+```sh
+oc delete project openshift-logging
+oc delete CatalogSourceConfig -n openshift-marketplace installed-community-openshift-operators
+oc delete subscription -n openshift-operators elasticsearch-operator
+oc delete CatalogSourceConfig -n openshift-marketplace installed-community-openshift-logging
+oc delete crd clusterloggings.logging.openshift.io
+oc delete crd elasticsearches.logging.openshift.io
+```

--- a/roles/infrastructure-nodes/files/infra.sh
+++ b/roles/infrastructure-nodes/files/infra.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export NAME="infra-$1"
+oc get machineset -n openshift-machine-api -o json\
+  | jq '.items[0]'\
+  | jq '.metadata.name=env["NAME"]'\
+  | jq '.spec.selector.matchLabels."machine.openshift.io/cluster-api-machineset"=env["NAME"]'\
+  | jq '.spec.template.metadata.labels."machine.openshift.io/cluster-api-machineset"=env["NAME"]'\
+  | jq '.spec.template.spec.metadata.labels."node-role.kubernetes.io/infra"=""'\
+  | jq 'del (.metadata.annotations)'\
+  | jq '.spec.replicas=3'\
+  | oc create -f -
+

--- a/roles/infrastructure-nodes/tasks/main.yml
+++ b/roles/infrastructure-nodes/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: register list of machinesets
+  shell: "oc get machineset -n openshift-machine-api"
+  register: infra_machineset_exists
+
+# stdout will have the word infra if there's already an infra machineset
+# if there is one, we don't create any
+
+- name: create infra machineset(s)
+  script: files/infra.sh {{ item }}
+  loop: "{{ azs }}"
+  when: '"infra" not in infra_machineset_exists.stdout'
+
+# move router (doesn't work yet)
+
+- name: move monitoring onto infra nodes
+  shell: "oc create -f https://raw.githubusercontent.com/openshift/training/master/assets/cluster-monitoring-configmap.yaml"

--- a/roles/istio-control-plane/README.md
+++ b/roles/istio-control-plane/README.md
@@ -1,0 +1,1 @@
+This role requires that a parameter/variable `api_url` point to the OpenShift API URL.

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -1,0 +1,173 @@
+# vim: set ft=ansible
+
+### logging project
+- name: logging project
+  k8s: 
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-logging
+        annotations:
+          openshift.io/node-selector: "" 
+        labels:
+          openshift.io/cluster-logging: "true"
+          openshift.io/cluster-monitoring: "true"
+
+- name: logging operatorgroup
+  k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha2
+      kind: OperatorGroup
+      metadata:
+        annotations:
+          olm.providedAPIs: ClusterLogging.v1alpha1.logging.openshift.io
+        name: openshift-logging
+        namespace: openshift-logging
+      spec:
+        selector: {}
+        serviceAccount:
+          metadata:
+            creationTimestamp: null
+        targetNamespaces:
+        - openshift-logging
+
+### elastic catalog source config
+- name: catalog source config
+  k8s:
+    state: present
+    definition:
+      apiVersion: marketplace.redhat.com/v1alpha1
+      kind: CatalogSourceConfig
+      metadata:
+        name: installed-community-openshift-operators
+        namespace: openshift-marketplace
+      spec:
+        csDisplayName: Community Operators
+        csPublisher: Community
+        packages: elasticsearch-operator
+        targetNamespace: openshift-operators
+
+### elastic subscription
+- name: elastic subscription
+  k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: elasticsearch-operator
+        namespace: openshift-operators
+      spec:
+        channel: preview
+        installPlanApproval: Automatic
+        name: elasticsearch-operator
+        source: installed-community-openshift-operators
+        sourceNamespace: openshift-operators
+        startingCSV: elasticsearch-operator.v0.0.1
+
+### logging catalog source config
+- name: logging catalog source config
+  k8s:
+    state: present
+    definition:
+      apiVersion: marketplace.redhat.com/v1alpha1
+      kind: CatalogSourceConfig
+      metadata:
+        generation: 1
+        name: installed-community-openshift-logging
+        namespace: openshift-marketplace
+      spec:
+        csDisplayName: Community Operators
+        csPublisher: Community
+        packages: cluster-logging
+        targetNamespace: openshift-logging
+
+### logging subscription
+- name: logging subscription
+  k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: cluster-logging
+        namespace: openshift-logging
+      spec:
+        channel: preview
+        installPlanApproval: Automatic
+        name: cluster-logging
+        source: installed-community-openshift-logging
+        sourceNamespace: openshift-logging
+        startingCSV: clusterlogging.v0.0.1
+
+- name: wait for elasticsearch and logging crds
+  shell: "oc get crd/{{ item }}"
+  retries: 10
+  delay: 30
+  with_items:
+    - "clusterloggings.logging.openshift.io"
+    - "elasticsearches.logging.openshift.io"
+
+- name: logging cr
+  k8s:
+    state: present
+    definition:
+      apiVersion: "logging.openshift.io/v1alpha1"
+      kind: "ClusterLogging"
+      metadata:
+        name: "instance"
+        namespace: "openshift-logging"
+      spec:
+        managementState: "Managed"
+        logStore:
+          type: "elasticsearch"
+          elasticsearch:
+            nodeCount: 3
+            storage: {}
+            redundancyPolicy: "SingleRedundancy"
+            nodeSelector: 
+              node-role.kubernetes.io/infra: ""
+            resources:
+              request:
+                memory: 4G
+        visualization:
+          type: "kibana"
+          kibana:
+            replicas: 1
+            nodeSelector: 
+              node-role.kubernetes.io/infra: ""
+        curation:
+          type: "curator"
+          curator:
+            schedule: "30 3 * * *"
+            nodeSelector: 
+              node-role.kubernetes.io/infra: ""
+        collection:
+          logs:
+            type: "fluentd"
+            fluentd: {}
+            nodeSelector: 
+              node-role.kubernetes.io/infra: ""
+
+- name: wait for elasticsearch deployments to exist
+  shell: "oc get deployment -n openshift-logging -l component=elasticsearch -o name"
+  register: pods_out
+  until: pods_out.stdout != ""
+  retries: 10
+  delay: 60
+
+- name: find elasticsearch deployments
+  shell: "oc get deployment -n openshift-logging -l component=elasticsearch -o name"
+  register: pods_out
+  failed_when: pods_out.rc >= 2
+
+- name: wait for running elasticsearch
+  shell: "oc get {{ item }} -n openshift-logging -o jsonpath='{.status.readyReplicas}'"
+  register: replicas_out
+  retries: 10
+  delay: 60
+  with_items: "{{ pods_out.stdout_lines }}"
+  until: replicas_out.stdout | int == 1


### PR DESCRIPTION
This can automatically create infrastructure nodes in the specified regions and can also deploy logging.

the logging role assumes you have infrastructure nodes, but does not enforce it